### PR TITLE
fix/can-not-create-pos-with-election-filling-type

### DIFF
--- a/__tests__/CanCommunity.test.ts
+++ b/__tests__/CanCommunity.test.ts
@@ -590,7 +590,21 @@ describe('test CanCommunity', () => {
 
       const cif = new CanCommunity(_options, canPass);
 
-      const input = {};
+      const input = {
+        community_account: 'test-community',
+        creator: 'creator',
+        pos_name: 'leader',
+        max_holder: 3,
+        filled_through: 0,
+        term: 0,
+        next_term_start_at: 0,
+        voting_period: 0,
+        pass_rule: 0,
+        pos_candidate_accounts: [],
+        pos_voter_accounts: [],
+        pos_candidate_positions: [],
+        pos_voter_positions: [],
+      };
       const packedParams = faker.lorem.words();
 
       const execCode = jest.spyOn(cif, 'execCode');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cif-js",
-  "version": "0.9.13",
+  "version": "0.9.15",
   "description": "cif-js",
   "license": "MIT",
   "repository": {

--- a/src/CanCommunity.ts
+++ b/src/CanCommunity.ts
@@ -344,6 +344,14 @@ export class CanCommunity {
         pos_candidate_positions: [],
         pos_voter_positions: [],
       };
+    } else {
+      input = {
+        ...input,
+        pos_candidate_accounts: input.pos_candidate_accounts || [],
+        pos_voter_accounts: input.pos_voter_accounts || [],
+        pos_candidate_positions: input.pos_candidate_positions || [],
+        pos_voter_positions: input.pos_voter_positions || [],
+      };
     }
     const packedParams = await serializeActionData(this.config, ActionNameEnum.CREATEPOS, input);
 

--- a/src/CanCommunity.ts
+++ b/src/CanCommunity.ts
@@ -366,6 +366,27 @@ export class CanCommunity {
   }
 
   async configurePosition(input: Configpos, execCodeInput?: ExecCodeInput): Promise<any> {
+    if (input.filled_through === FillingType.APPOINTMENT) {
+      input = {
+        ...input,
+        term: 0,
+        next_term_start_at: 0,
+        voting_period: 0,
+        pass_rule: 0,
+        pos_candidate_accounts: [],
+        pos_voter_accounts: [],
+        pos_candidate_positions: [],
+        pos_voter_positions: [],
+      };
+    } else {
+      input = {
+        ...input,
+        pos_candidate_accounts: input.pos_candidate_accounts || [],
+        pos_voter_accounts: input.pos_voter_accounts || [],
+        pos_candidate_positions: input.pos_candidate_positions || [],
+        pos_voter_positions: input.pos_voter_positions || [],
+      };
+    }
     const packedParams = await serializeActionData(this.config, ActionNameEnum.CONFIGPOS, input);
 
     const codeActions: ExecutionCodeData[] = [


### PR DESCRIPTION
This merge did:

- fix can not create position with election filling type because missing parameter when pack action data
- fix can not config position with appointment filling type because missing parameter when pack action data
- add default empty array value if election configuration parameter such as pos_candidate_accounts, pos_voter_accounts, pos_candidate_positions, pos_voter_positions... is not specify

/cc @phanduy12214 